### PR TITLE
[feat] 사이드바 컴포넌트 추가

### DIFF
--- a/src/app/_component/SideBar.tsx
+++ b/src/app/_component/SideBar.tsx
@@ -8,7 +8,7 @@ import Link from 'next/link'
 export default function SideBar() {
   const categories = [
     { id: 'home', path: '', label: '홈' },
-    { id: 'news', path: 'news/notice', label: '공지사항' },
+    { id: 'notices', path: 'news/notice', label: '공지사항' },
     { id: 'events', path: 'news/event', label: '이벤트' },
   ]
 

--- a/src/app/_component/SideBar.tsx
+++ b/src/app/_component/SideBar.tsx
@@ -8,7 +8,8 @@ import Link from 'next/link'
 export default function SideBar() {
   const categories = [
     { id: 'home', path: '', label: '홈' },
-    { id: 'news', path: 'news', label: '공지사항' },
+    { id: 'news', path: 'news/notice', label: '공지사항' },
+    { id: 'events', path: 'news/event', label: '이벤트' },
   ]
 
   return (

--- a/src/app/_component/SideBar.tsx
+++ b/src/app/_component/SideBar.tsx
@@ -1,0 +1,25 @@
+/**
+ * @description 페이지에서 공통으로 사용되는 사이드바 컴포넌트
+ */
+'use client'
+
+import Link from 'next/link'
+
+export default function SideBar() {
+  const categories = [
+    { id: 'home', path: '', label: '홈' },
+    { id: 'news', path: 'news', label: '공지사항' },
+  ]
+
+  return (
+    <nav>
+      <ul>
+        {categories.map((category) => (
+          <li key={category.id}>
+            <Link href={`/${category.path}`}>{category.label}</Link>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,10 +24,8 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body className={clsx([Pretendard.className])}>
-        <div>
-          <SideBar />
-          <main>{children}</main>
-        </div>
+        <SideBar />
+        <main>{children}</main>
       </body>
     </html>
   )

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from 'next'
 import localFont from 'next/font/local'
 
 import './reset.scss'
+import SideBar from './_component/SideBar'
 
 // 무료 폰트
 const Pretendard = localFont({
@@ -22,7 +23,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko">
-      <body className={clsx([Pretendard.className])}>{children}</body>
+      <body className={clsx([Pretendard.className])}>
+        <div>
+          <SideBar />
+          <main>{children}</main>
+        </div>
+      </body>
     </html>
   )
 }

--- a/src/app/news/event/error.tsx
+++ b/src/app/news/event/error.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export default function error() {
+  return <section>임시 에러 페이지 입니다.</section>
+}

--- a/src/app/news/event/page.tsx
+++ b/src/app/news/event/page.tsx
@@ -1,0 +1,16 @@
+import { EventList } from '@/model/news/events'
+import getEventList from '../_actions/getEventList'
+
+/**
+ * @description
+ * 이벤트 테스트 페이지 (임시))
+ */
+export default async function page() {
+  const eventList: EventList = await getEventList()
+
+  return (
+    <section>
+      {eventList && eventList.map((event) => <div>{event.Title}</div>)}
+    </section>
+  )
+}

--- a/src/app/news/notice/_component/Tab.tsx
+++ b/src/app/news/notice/_component/Tab.tsx
@@ -1,0 +1,10 @@
+'use client'
+
+export default function Tab() {
+  return (
+    <div>
+      <div>공지사항</div>
+      <div>탭메뉴</div>
+    </div>
+  )
+}

--- a/src/app/news/notice/error.tsx
+++ b/src/app/news/notice/error.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export default function error() {
+  return <section>임시 에러 페이지 입니다.</section>
+}

--- a/src/app/news/notice/page.tsx
+++ b/src/app/news/notice/page.tsx
@@ -1,0 +1,18 @@
+import { NoticeList } from '@/model/news/notices'
+import getNoticeList from '../_actions/getNoticeList'
+import Tab from './_component/Tab'
+
+/**
+ * @description
+ * 공지사항 테스트 페이지 (임시))
+ */
+export default async function page() {
+  const noticeList: NoticeList = await getNoticeList()
+
+  return (
+    <section>
+      <Tab />
+      {noticeList && noticeList.map((notice) => <div>{notice.Title}</div>)}
+    </section>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,3 @@
 export default function page() {
-  return <section>초기 세팅중입니다.</section>
+  return <section>홈페이지</section>
 }


### PR DESCRIPTION
사이드바 컴포넌트 추가

모든 페이지에 공통으로 사용돼서 레이아웃에 추가했는데 이래도 되는지?

사이드바 컴포넌트를 어디에 생성할지 몰라서 src/app 폴더 안에 _component 폴더를 만들어서 그 안에 생성함 이래도 되는지?
src/ui 폴더에 안 넣은 이유는 사이드바는 레이아웃에 한 번만 쓰여서 그랬음